### PR TITLE
Change package to module in the repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Building From the Source
 If you want to build Ballerina Kafka client endpoint from the source code:
 
 1. Get a clone or download the source from this repository:
-    https://github.com/wso2-ballerina/package-kafka
+    https://github.com/wso2-ballerina/module-kafka
 2. Run the following Maven command from the ballerina directory:
     mvn clean install
 3. Extract the distribution created at `/component/target/wso2-kafka-<version>.zip`. Run the install.{sh/bat} script to install the package.


### PR DESCRIPTION
## Purpose
> Change GitHub repository link to `module-kafka` from `package-kafka`.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes