### PR TITLE
Bump Debezium version to a stable release

### DIFF
--- a/component/src/test/resources/consumer/kafka_consumer.bal
+++ b/component/src/test/resources/consumer/kafka_consumer.bal
@@ -28,26 +28,26 @@ kafka:ConsumerConfig consumerConfigNegative = {};
 kafka:SimpleConsumer negativeConsumer = new (consumerConfigNegative);
 
 function funcKafkaConnect() returns kafka:SimpleConsumer {
-    kafka:SimpleConsumer kafkaConsumer = new(consumerConfig);
-    return kafkaConsumer;
+    return new(consumerConfig);
 }
 
 function funcKafkaConnectNegative() returns error? {
-    error? results = negativeConsumer->connect();
-    return results;
+    return negativeConsumer->connect();
 }
 
 function funcKafkaClose(kafka:SimpleConsumer consumer) returns boolean {
     kafka:SimpleConsumer consumerEP = consumer;
     var conErr = consumerEP->close();
+    if (conErr is error) {
+        return false;
+    }
     return true;
 }
 
 function funcKafkaGetSubscription(kafka:SimpleConsumer consumer) returns string[]|error {
     kafka:SimpleConsumer consumerEP = consumer;
     string[] topics = [];
-    topics = check consumerEP->getSubscription();
-    return topics;
+    return consumerEP->getSubscription();
 }
 
 function funcKafkaGetAssignment(kafka:SimpleConsumer consumer) returns kafka:TopicPartition[]|error {

--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,7 @@
     <properties>
         <scala.version>2.11.0</scala.version>
         <version.kafka.scala>2.11</version.kafka.scala>
-        <debezium.version>0.9.0.Beta2</debezium.version>
+        <debezium.version>0.9.2.Final</debezium.version>
         <awaitility.version>3.0.0</awaitility.version>
         <project.scm.id>my-scm-server</project.scm.id>
         <ballerina.version>0.990.3</ballerina.version>


### PR DESCRIPTION
## Purpose
> Bump Debezium (The library used for create Kafka clusters in tests) to latest, stable release.
> Improve code quality of some test files.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes